### PR TITLE
Alert som trigges ved lang responstid for et endepunkt

### DIFF
--- a/.nais/alerts-common.yaml
+++ b/.nais/alerts-common.yaml
@@ -42,7 +42,7 @@
       severity: danger
     # Sjekk om endepunkter har unaturlig lang responstid
     - alert: Lang responstid for endepunkt
-      expr: (sum by(app, uri)(increase(http_server_requests_seconds_sum{status="200",kubernetes_namespace="meldekort",uri!~"/actuator.*|/internal.*"}[3m])) / sum by(app, uri)(increase(http_server_requests_seconds_count{status="200",kubernetes_namespace="meldekort",uri!~"/actuator.*|/internal.*"}[3m]))) > 0
+      expr: (sum by(app, uri)(increase(http_server_requests_seconds_sum{status="200",kubernetes_namespace="{{ namespace }}",uri!~"/.*actuator.*|/.*internal.*"}[3m])) / sum by(app, uri)(increase(http_server_requests_seconds_count{status="200",kubernetes_namespace="{{ namespace }}",uri!~"/.*actuator.*|/.*internal.*"}[3m]))) > 2
       for: 3m
       description: '*\{{ $labels.app }}* endepunkt *\{{ $labels.uri }}* har lang responstid.'
       action: 'Sjekk aktuelt Grafana-dashboard for \{{ $labels.app }}.'

--- a/.nais/alerts-common.yaml
+++ b/.nais/alerts-common.yaml
@@ -40,3 +40,10 @@
       description: '*\{{ $labels.app }}* pod *\{{ $labels.kubernetes_pod_name }}* har startet unaturlig mange tråder.'
       action: 'Sjekk JVM metrics i NAIS App Dashboard for \{{ $labels.app }}. Lukkes f.eks HTTP-klienten riktig?'
       severity: danger
+    # Sjekk om endepunkter har unaturlig lang responstid
+    - alert: Lang responstid for endepunkt
+      expr: (sum by(app, uri)(increase(http_server_requests_seconds_sum{status="200",kubernetes_namespace="meldekort",uri!~"/actuator.*|/internal.*"}[3m])) / sum by(app, uri)(increase(http_server_requests_seconds_count{status="200",kubernetes_namespace="meldekort",uri!~"/actuator.*|/internal.*"}[3m]))) > 0
+      for: 3m
+      description: '*\{{ $labels.app }}* endepunkt *\{{ $labels.uri }}* har lang responstid.'
+      action: 'Sjekk aktuelt Grafana-dashboard for \{{ $labels.app }}.'
+      severity: warning


### PR DESCRIPTION
Vi ønsker å fange opp at responstiden blir unormalt lang for enkelte endepunkter. Eks:
![image](https://user-images.githubusercontent.com/42343764/199742892-5a1e52ad-6ad5-4b33-b883-30351c7a1ce1.png)

