### PR TITLE
Meldeplikt 475 PrometheusRule

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -34,6 +34,10 @@ jobs:
       #          cat .nais/alerts-common.yaml >> ${{ env.RESOURCE_FILE_DEV }}
       #          cat ${{ env.RESOURCE_FILE_DEV }} .nais/alerts-fss.yaml > ${{ env.RESOURCE_FILE_DEV_FSS }}
 
+      - name: Temp debug
+        run: |
+          cat ${{ env.RESOURCE_FILE_DEV_GCP }}
+          cat ${{ env.VARS_FILE }}
 
 #      - name: Deploy to dev-fss
 #        uses: nais/deploy/actions/deploy@v1

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -40,6 +40,7 @@ jobs:
           CLUSTER: dev-fss
           RESOURCE: ${{ env.RESOURCE_FILE_DEV_FSS }}
           VARS: ${{ env.VARS_FILE }}
+          TEAM: meldekort
           PRINT_PAYLOAD: true
 
       - name: Deploy to dev-gcp

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -51,4 +51,5 @@ jobs:
           CLUSTER: dev-gcp
           RESOURCE: ${{ env.RESOURCE_FILE_DEV_GCP }}
           VARS: ${{ env.VARS_FILE }}
+          TEAM: meldekort
           PRINT_PAYLOAD: true

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -5,11 +5,11 @@ on:
       - 'master'
     paths:
       - .github/workflows/deploy-dev.yaml
-      - .nais/meldeplikt-alerts-dev.yaml
-      - .nais/vars.yaml
       - .nais/alerts-common.yaml
       - .nais/alerts-fss.yaml
       - .nais/alerts-gcp.yaml
+      - .nais/meldeplikt-alerts-dev.yaml
+      - .nais/vars.yaml
   workflow_dispatch:
 
 env:
@@ -30,7 +30,6 @@ jobs:
         run: |
           cat .nais/alerts-common.yaml >> ${{ env.RESOURCE_FILE_DEV }}
           cat ${{ env.RESOURCE_FILE_DEV }} .nais/alerts-fss.yaml > ${{ env.RESOURCE_FILE_DEV_FSS }}
-          touch ${{ env.RESOURCE_FILE_DEV }}
           cat ${{ env.RESOURCE_FILE_DEV }} .nais/alerts-gcp.yaml > ${{ env.RESOURCE_FILE_DEV_GCP }}
 
       - name: Deploy to dev-fss

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -28,18 +28,19 @@ jobs:
 
       - name: Append alerts
         run: |
-          cat .nais/alerts-common.yaml >> ${{ env.RESOURCE_FILE_DEV }}
-          cat ${{ env.RESOURCE_FILE_DEV }} .nais/alerts-fss.yaml > ${{ env.RESOURCE_FILE_DEV_FSS }}
+#          cat .nais/alerts-common.yaml >> ${{ env.RESOURCE_FILE_DEV }}
+          touch ${{ env.RESOURCE_FILE_DEV }}
+#          cat ${{ env.RESOURCE_FILE_DEV }} .nais/alerts-fss.yaml > ${{ env.RESOURCE_FILE_DEV_FSS }}
           cat ${{ env.RESOURCE_FILE_DEV }} .nais/alerts-gcp.yaml > ${{ env.RESOURCE_FILE_DEV_GCP }}
 
-      - name: Deploy to dev-fss
-        uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-fss
-          RESOURCE: ${{ env.RESOURCE_FILE_DEV_FSS }}
-          VARS: ${{ env.VARS_FILE }}
-          PRINT_PAYLOAD: true
+#      - name: Deploy to dev-fss
+#        uses: nais/deploy/actions/deploy@v1
+#        env:
+#          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+#          CLUSTER: dev-fss
+#          RESOURCE: ${{ env.RESOURCE_FILE_DEV_FSS }}
+#          VARS: ${{ env.VARS_FILE }}
+#          PRINT_PAYLOAD: true
 
       - name: Deploy to dev-gcp
         uses: nais/deploy/actions/deploy@v1

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -28,10 +28,12 @@ jobs:
 
       - name: Append alerts
         run: |
-#          cat .nais/alerts-common.yaml >> ${{ env.RESOURCE_FILE_DEV }}
           touch ${{ env.RESOURCE_FILE_DEV }}
-#          cat ${{ env.RESOURCE_FILE_DEV }} .nais/alerts-fss.yaml > ${{ env.RESOURCE_FILE_DEV_FSS }}
           cat ${{ env.RESOURCE_FILE_DEV }} .nais/alerts-gcp.yaml > ${{ env.RESOURCE_FILE_DEV_GCP }}
+
+      #          cat .nais/alerts-common.yaml >> ${{ env.RESOURCE_FILE_DEV }}
+      #          cat ${{ env.RESOURCE_FILE_DEV }} .nais/alerts-fss.yaml > ${{ env.RESOURCE_FILE_DEV_FSS }}
+
 
 #      - name: Deploy to dev-fss
 #        uses: nais/deploy/actions/deploy@v1

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -28,25 +28,19 @@ jobs:
 
       - name: Append alerts
         run: |
+          cat .nais/alerts-common.yaml >> ${{ env.RESOURCE_FILE_DEV }}
+          cat ${{ env.RESOURCE_FILE_DEV }} .nais/alerts-fss.yaml > ${{ env.RESOURCE_FILE_DEV_FSS }}
           touch ${{ env.RESOURCE_FILE_DEV }}
           cat ${{ env.RESOURCE_FILE_DEV }} .nais/alerts-gcp.yaml > ${{ env.RESOURCE_FILE_DEV_GCP }}
 
-      #          cat .nais/alerts-common.yaml >> ${{ env.RESOURCE_FILE_DEV }}
-      #          cat ${{ env.RESOURCE_FILE_DEV }} .nais/alerts-fss.yaml > ${{ env.RESOURCE_FILE_DEV_FSS }}
-
-      - name: Temp debug
-        run: |
-          cat ${{ env.RESOURCE_FILE_DEV_GCP }}
-          cat ${{ env.VARS_FILE }}
-
-#      - name: Deploy to dev-fss
-#        uses: nais/deploy/actions/deploy@v1
-#        env:
-#          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-#          CLUSTER: dev-fss
-#          RESOURCE: ${{ env.RESOURCE_FILE_DEV_FSS }}
-#          VARS: ${{ env.VARS_FILE }}
-#          PRINT_PAYLOAD: true
+      - name: Deploy to dev-fss
+        uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-fss
+          RESOURCE: ${{ env.RESOURCE_FILE_DEV_FSS }}
+          VARS: ${{ env.VARS_FILE }}
+          PRINT_PAYLOAD: true
 
       - name: Deploy to dev-gcp
         uses: nais/deploy/actions/deploy@v1

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -40,7 +40,6 @@ jobs:
           CLUSTER: dev-fss
           RESOURCE: ${{ env.RESOURCE_FILE_DEV_FSS }}
           VARS: ${{ env.VARS_FILE }}
-          TEAM: meldekort
           PRINT_PAYLOAD: true
 
       - name: Deploy to dev-gcp
@@ -50,5 +49,4 @@ jobs:
           CLUSTER: dev-gcp
           RESOURCE: ${{ env.RESOURCE_FILE_DEV_GCP }}
           VARS: ${{ env.VARS_FILE }}
-          TEAM: meldekort
           PRINT_PAYLOAD: true

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,11 +5,11 @@ on:
       - 'master'
     paths:
       - .github/workflows/deploy.yaml
-      - .nais/meldeplikt-alerts.yaml
-      - .nais/vars.yaml
       - .nais/alerts-common.yaml
       - .nais/alerts-fss.yaml
       - .nais/alerts-gcp.yaml
+      - .nais/meldeplikt-alerts.yaml
+      - .nais/vars.yaml
   workflow_dispatch:
 
 env:

--- a/.nais/alerts-common.yaml
+++ b/.nais/alerts-common.yaml
@@ -2,48 +2,69 @@
       - alert: Applikasjon er nede
         expr: kube_deployment_status_replicas_available{namespace="{{ namespace }}"} == 0
         for: 3m
-        description: '*\{{ $labels.deployment }}* er nede i namespace \{{ $labels.namespace }}.'
-        action: 'Kjør `kubectl describe pod -l app=\{{ $labels.deployment }} -n \{{ $labels.namespace }}` for å se events, og `kubectl logs -l app=\{{ $labels.deployment }} -n \{{ $labels.namespace }}` for logger. Sjekk også Kibana for eventuelle feil som er logget, query `application: \{{ $labels.deployment }} AND (level:Error OR level:Warning)`.'
-        severity: danger
+        annotations:
+          consequence: '*\{{ $labels.deployment }}* er nede i namespace \{{ $labels.namespace }}.'
+          action: 'Kjør `kubectl describe pod -l app=\{{ $labels.deployment }} -n \{{ $labels.namespace }}` for å se events, og `kubectl logs -l app=\{{ $labels.deployment }} -n \{{ $labels.namespace }}` for logger. Sjekk også Kibana for eventuelle feil som er logget, query `application: \{{ $labels.deployment }} AND (level:Error OR level:Warning)`.'
+        labels:
+          namespace: {{ namespace }}
+          severity: danger
       # Sjekker om containere restartes flere ganger
       - alert: Applikasjon restarter kontinuerlig
         expr: sum(increase(kube_pod_container_status_restarts_total{namespace="{{ namespace }}"}[5m])) by (container) > 3
         for: 3m
-        description: '*\{{ $labels.container }}* har restartet flere ganger den siste halvtimen.'
-        action: 'Se `kubectl describe pod \{{ $labels.container }} -n {{ namespace }}` for å se events, og `kubectl logs -l app=\{{ $labels.container }} -n {{ namespace }}` for logger.'
-        severity: danger
+        annotations:
+          consequence: '*\{{ $labels.container }}* har restartet flere ganger den siste halvtimen.'
+          action: 'Se `kubectl describe pod \{{ $labels.container }} -n {{ namespace }}` for å se events, og `kubectl logs -l app=\{{ $labels.container }} -n {{ namespace }}` for logger.'
+        labels:
+          namespace: {{ namespace }}
+          severity: danger
       # Sjekker om en applikasjon har logget mange feil nylig
       - alert: Høy feilrate i logger
         expr: (100 * sum by (log_app, log_namespace) (rate(logd_messages_total{log_namespace="{{ namespace }}",log_level=~"Warning|Error"}[3m])) / sum by (log_app, log_namespace) (rate(logd_messages_total{log_namespace="{{ namespace }}"}[3m]))) > 10
         for: 3m
-        description: '*\{{ $labels.log_app }}* har logget høy andel feil.'
-        action: "Sjekk loggene til app \{{ $labels.log_app }} i namespace \{{ $labels.log_namespace }} for å se hvorfor det er så mye feil."
-        severity: warning
+        annotations:
+          consequence: '*\{{ $labels.log_app }}* har logget høy andel feil.'
+          action: "Sjekk loggene til app \{{ $labels.log_app }} i namespace \{{ $labels.log_namespace }} for å se hvorfor det er så mye feil."
+        labels:
+          namespace: {{ namespace }}
+          severity: warning
       # Sjekk HTTP 5xx-serverfeil
       - alert: Høy andel HTTP serverfeil (5xx-responser)
         expr: (100 * (sum by (service) (rate(nginx_ingress_controller_requests{status=~"^5\\d\\d", namespace="{{ namespace }}"}[3m])) / sum by (service) (rate(nginx_ingress_controller_requests{namespace="{{ namespace }}"}[3m])))) > 1
         for: 3m
-        description: '*\{{ $labels.service }}* har logget mange feil.'
-        action: 'Sjekk loggene for å se hvorfor \{{ $labels.service }} returnerer HTTP 5xx-feilresponser.'
-        severity: danger
+        annotations:
+          consequence: '*\{{ $labels.service }}* har logget mange feil.'
+          action: 'Sjekk loggene for å se hvorfor \{{ $labels.service }} returnerer HTTP 5xx-feilresponser.'
+        labels:
+          namespace: {{ namespace }}
+          severity: danger
       # Sjekk HTTP 4xx-klientfeil. Filtrerer vekk stille perioder for å unngå falske alarmer
       - alert: Høy andel HTTP klientfeil (4xx-responser)
         expr: (100 * (sum by (service) (rate(nginx_ingress_controller_requests{status=~"^4\\d\\d", namespace="{{ namespace }}"}[3m])) / sum by (service) (rate(nginx_ingress_controller_requests{namespace="{{ namespace }}"}[3m])))) > 20 and (sum by (service) (rate(nginx_ingress_controller_requests{namespace="{{ namespace }}"}[3m]))) > 3
         for: 3m
-        description: '*\{{ $labels.service }}* har logget mange feil.'
-        action: 'Sjekk loggene for å se hvorfor \{{ $labels.service }} returnerer HTTP 4xx-feilresponser.'
-        severity: warning
+        annotations:
+          consequence: '*\{{ $labels.service }}* har logget mange feil.'
+          action: 'Sjekk loggene for å se hvorfor \{{ $labels.service }} returnerer HTTP 4xx-feilresponser.'
+        labels:
+          namespace: {{ namespace }}
+          severity: warning
       # Sjekk hvorfor en pod starter unaturlig mange tråder
       - alert: Høy threadcount for en pod
         expr: sum(jvm_threads_live_threads{namespace="{{ namespace }}"}) by (pod, app) > 100
         for: 3m
-        description: '*\{{ $labels.app }}* pod *\{{ $labels.pod }}* har startet unaturlig mange tråder.'
-        action: 'Sjekk JVM metrics i NAIS App Dashboard for \{{ $labels.app }}. Lukkes f.eks HTTP-klienten riktig?'
-        severity: danger
+        annotations:
+          consequence: '*\{{ $labels.app }}* pod *\{{ $labels.pod }}* har startet unaturlig mange tråder.'
+          action: 'Sjekk JVM metrics i NAIS App Dashboard for \{{ $labels.app }}. Lukkes f.eks HTTP-klienten riktig?'
+        labels:
+          namespace: {{ namespace }}
+          severity: danger
       # Sjekk om endepunkter har unaturlig lang responstid
       - alert: Lang responstid for endepunkt
         expr: (sum by(app, uri)(increase(http_server_requests_seconds_sum{status="200", app!="meldekort-api", namespace="{{ namespace }}",uri!~"/.*actuator.*|/.*internal.*"}[3m])) / sum by(app, uri)(increase(http_server_requests_seconds_count{status="200", app!="meldekort-api", namespace="{{ namespace }}",uri!~"/.*actuator.*|/.*internal.*"}[3m]))) > 2
         for: 3m
-        description: '*\{{ $labels.app }}* endepunkt *\{{ $labels.uri }}* har lang responstid.'
-        action: 'Sjekk aktuelt Grafana-dashboard for \{{ $labels.app }}.'
-        severity: warning
+        annotations:
+          consequence: '*\{{ $labels.app }}* endepunkt *\{{ $labels.uri }}* har lang responstid.'
+          action: 'Sjekk aktuelt Grafana-dashboard for \{{ $labels.app }}.'
+        labels:
+          namespace: {{ namespace }}
+          severity: warning

--- a/.nais/alerts-common.yaml
+++ b/.nais/alerts-common.yaml
@@ -1,49 +1,49 @@
-    # Sjekker om en eller flere applikasjoner er nede i namespace meldekort, dvs. at det ikke finnes noen kjørende podder
-    - alert: Applikasjon er nede
-      expr: kube_deployment_status_replicas_available{namespace="{{ namespace }}"} == 0
-      for: 3m
-      description: '*\{{ $labels.deployment }}* er nede i namespace \{{ $labels.namespace }}.'
-      action: 'Kjør `kubectl describe pod -l app=\{{ $labels.deployment }} -n \{{ $labels.namespace }}` for å se events, og `kubectl logs -l app=\{{ $labels.deployment }} -n \{{ $labels.namespace }}` for logger. Sjekk også Kibana for eventuelle feil som er logget, query `application: \{{ $labels.deployment }} AND (level:Error OR level:Warning)`.'
-      severity: danger
-    # Sjekker om containere restartes flere ganger
-    - alert: Applikasjon restarter kontinuerlig
-      expr: sum(increase(kube_pod_container_status_restarts_total{namespace="{{ namespace }}"}[5m])) by (container) > 3
-      for: 3m
-      description: '*\{{ $labels.container }}* har restartet flere ganger den siste halvtimen.'
-      action: 'Se `kubectl describe pod \{{ $labels.container }} -n {{ namespace }}` for å se events, og `kubectl logs -l app=\{{ $labels.container }} -n {{ namespace }}` for logger.'
-      severity: danger
-    # Sjekker om en applikasjon har logget mange feil nylig
-    - alert: Høy feilrate i logger
-      expr: (100 * sum by (log_app, log_namespace) (rate(logd_messages_total{log_namespace="{{ namespace }}",log_level=~"Warning|Error"}[3m])) / sum by (log_app, log_namespace) (rate(logd_messages_total{log_namespace="{{ namespace }}"}[3m]))) > 10
-      for: 3m
-      description: '*\{{ $labels.log_app }}* har logget høy andel feil.'
-      action: "Sjekk loggene til app \{{ $labels.log_app }} i namespace \{{ $labels.log_namespace }} for å se hvorfor det er så mye feil."
-      severity: warning
-    # Sjekk HTTP 5xx-serverfeil
-    - alert: Høy andel HTTP serverfeil (5xx-responser)
-      expr: (100 * (sum by (service) (rate(nginx_ingress_controller_requests{status=~"^5\\d\\d", namespace="{{ namespace }}"}[3m])) / sum by (service) (rate(nginx_ingress_controller_requests{namespace="{{ namespace }}"}[3m])))) > 1
-      for: 3m
-      description: '*\{{ $labels.service }}* har logget mange feil.'
-      action: 'Sjekk loggene for å se hvorfor \{{ $labels.service }} returnerer HTTP 5xx-feilresponser.'
-      severity: danger
-    # Sjekk HTTP 4xx-klientfeil. Filtrerer vekk stille perioder for å unngå falske alarmer
-    - alert: Høy andel HTTP klientfeil (4xx-responser)
-      expr: (100 * (sum by (service) (rate(nginx_ingress_controller_requests{status=~"^4\\d\\d", namespace="{{ namespace }}"}[3m])) / sum by (service) (rate(nginx_ingress_controller_requests{namespace="{{ namespace }}"}[3m])))) > 20 and (sum by (service) (rate(nginx_ingress_controller_requests{namespace="{{ namespace }}"}[3m]))) > 3
-      for: 3m
-      description: '*\{{ $labels.service }}* har logget mange feil.'
-      action: 'Sjekk loggene for å se hvorfor \{{ $labels.service }} returnerer HTTP 4xx-feilresponser.'
-      severity: warning
-    # Sjekk hvorfor en pod starter unaturlig mange tråder
-    - alert: Høy threadcount for en pod
-      expr: sum(jvm_threads_live_threads{kubernetes_namespace="{{ namespace }}"}) by (kubernetes_pod_name, app) > 100
-      for: 3m
-      description: '*\{{ $labels.app }}* pod *\{{ $labels.kubernetes_pod_name }}* har startet unaturlig mange tråder.'
-      action: 'Sjekk JVM metrics i NAIS App Dashboard for \{{ $labels.app }}. Lukkes f.eks HTTP-klienten riktig?'
-      severity: danger
-    # Sjekk om endepunkter har unaturlig lang responstid
-    - alert: Lang responstid for endepunkt
-      expr: (sum by(app, uri)(increase(http_server_requests_seconds_sum{status="200", app!="meldekort-api", kubernetes_namespace="{{ namespace }}",uri!~"/.*actuator.*|/.*internal.*"}[3m])) / sum by(app, uri)(increase(http_server_requests_seconds_count{status="200", app!="meldekort-api", kubernetes_namespace="{{ namespace }}",uri!~"/.*actuator.*|/.*internal.*"}[3m]))) > 2
-      for: 3m
-      description: '*\{{ $labels.app }}* endepunkt *\{{ $labels.uri }}* har lang responstid.'
-      action: 'Sjekk aktuelt Grafana-dashboard for \{{ $labels.app }}.'
-      severity: warning
+      # Sjekker om en eller flere applikasjoner er nede i namespace meldekort, dvs. at det ikke finnes noen kjørende podder
+      - alert: Applikasjon er nede
+        expr: kube_deployment_status_replicas_available{namespace="{{ namespace }}"} == 0
+        for: 3m
+        description: '*\{{ $labels.deployment }}* er nede i namespace \{{ $labels.namespace }}.'
+        action: 'Kjør `kubectl describe pod -l app=\{{ $labels.deployment }} -n \{{ $labels.namespace }}` for å se events, og `kubectl logs -l app=\{{ $labels.deployment }} -n \{{ $labels.namespace }}` for logger. Sjekk også Kibana for eventuelle feil som er logget, query `application: \{{ $labels.deployment }} AND (level:Error OR level:Warning)`.'
+        severity: danger
+      # Sjekker om containere restartes flere ganger
+      - alert: Applikasjon restarter kontinuerlig
+        expr: sum(increase(kube_pod_container_status_restarts_total{namespace="{{ namespace }}"}[5m])) by (container) > 3
+        for: 3m
+        description: '*\{{ $labels.container }}* har restartet flere ganger den siste halvtimen.'
+        action: 'Se `kubectl describe pod \{{ $labels.container }} -n {{ namespace }}` for å se events, og `kubectl logs -l app=\{{ $labels.container }} -n {{ namespace }}` for logger.'
+        severity: danger
+      # Sjekker om en applikasjon har logget mange feil nylig
+      - alert: Høy feilrate i logger
+        expr: (100 * sum by (log_app, log_namespace) (rate(logd_messages_total{log_namespace="{{ namespace }}",log_level=~"Warning|Error"}[3m])) / sum by (log_app, log_namespace) (rate(logd_messages_total{log_namespace="{{ namespace }}"}[3m]))) > 10
+        for: 3m
+        description: '*\{{ $labels.log_app }}* har logget høy andel feil.'
+        action: "Sjekk loggene til app \{{ $labels.log_app }} i namespace \{{ $labels.log_namespace }} for å se hvorfor det er så mye feil."
+        severity: warning
+      # Sjekk HTTP 5xx-serverfeil
+      - alert: Høy andel HTTP serverfeil (5xx-responser)
+        expr: (100 * (sum by (service) (rate(nginx_ingress_controller_requests{status=~"^5\\d\\d", namespace="{{ namespace }}"}[3m])) / sum by (service) (rate(nginx_ingress_controller_requests{namespace="{{ namespace }}"}[3m])))) > 1
+        for: 3m
+        description: '*\{{ $labels.service }}* har logget mange feil.'
+        action: 'Sjekk loggene for å se hvorfor \{{ $labels.service }} returnerer HTTP 5xx-feilresponser.'
+        severity: danger
+      # Sjekk HTTP 4xx-klientfeil. Filtrerer vekk stille perioder for å unngå falske alarmer
+      - alert: Høy andel HTTP klientfeil (4xx-responser)
+        expr: (100 * (sum by (service) (rate(nginx_ingress_controller_requests{status=~"^4\\d\\d", namespace="{{ namespace }}"}[3m])) / sum by (service) (rate(nginx_ingress_controller_requests{namespace="{{ namespace }}"}[3m])))) > 20 and (sum by (service) (rate(nginx_ingress_controller_requests{namespace="{{ namespace }}"}[3m]))) > 3
+        for: 3m
+        description: '*\{{ $labels.service }}* har logget mange feil.'
+        action: 'Sjekk loggene for å se hvorfor \{{ $labels.service }} returnerer HTTP 4xx-feilresponser.'
+        severity: warning
+      # Sjekk hvorfor en pod starter unaturlig mange tråder
+      - alert: Høy threadcount for en pod
+        expr: sum(jvm_threads_live_threads{namespace="{{ namespace }}"}) by (pod, app) > 100
+        for: 3m
+        description: '*\{{ $labels.app }}* pod *\{{ $labels.pod }}* har startet unaturlig mange tråder.'
+        action: 'Sjekk JVM metrics i NAIS App Dashboard for \{{ $labels.app }}. Lukkes f.eks HTTP-klienten riktig?'
+        severity: danger
+      # Sjekk om endepunkter har unaturlig lang responstid
+      - alert: Lang responstid for endepunkt
+        expr: (sum by(app, uri)(increase(http_server_requests_seconds_sum{status="200", app!="meldekort-api", namespace="{{ namespace }}",uri!~"/.*actuator.*|/.*internal.*"}[3m])) / sum by(app, uri)(increase(http_server_requests_seconds_count{status="200", app!="meldekort-api", namespace="{{ namespace }}",uri!~"/.*actuator.*|/.*internal.*"}[3m]))) > 2
+        for: 3m
+        description: '*\{{ $labels.app }}* endepunkt *\{{ $labels.uri }}* har lang responstid.'
+        action: 'Sjekk aktuelt Grafana-dashboard for \{{ $labels.app }}.'
+        severity: warning

--- a/.nais/alerts-gcp.yaml
+++ b/.nais/alerts-gcp.yaml
@@ -1,6 +1,6 @@
       # Sjekker om det er feil ved selftest
       - alert: Feil i selftest
-        expr: selftests_aggregate_result_status{namespace="{{ namespace }}"} > -1
+        expr: selftests_aggregate_result_status{namespace="{{ namespace }}"} > 0
         for: 1m
         annotations:
           consequence: '*\{{ $labels.app }}* har feil i selftest.'

--- a/.nais/alerts-gcp.yaml
+++ b/.nais/alerts-gcp.yaml
@@ -1,10 +1,23 @@
-      # Sjekker om det er feil ved selftest
-      - alert: Feil i selftest
-        expr: selftests_aggregate_result_status{namespace="{{ namespace }}"} > -1
-        for: 1m
+#      # Sjekker om det er feil ved selftest
+#      - alert: Feil i selftest
+#        expr: selftests_aggregate_result_status{namespace="{{ namespace }}"} > -1
+#        for: 1m
+#        annotations:
+#          consequence: '*\{{ $labels.app }}* har feil i selftest.'
+#          action: "Sjekk \{{ $labels.app }} i \{{ $labels.namespace }} sin selftest for å se hva som er galt."
+#        labels:
+#          namespace: {{ namespace }}
+#          severity: warning
+      - alert: InstanceDown
+        expr: count(up) == 0
+        for: 5m
         annotations:
-          consequence: '*\{{ $labels.app }}* har feil i selftest.'
-          action: "Sjekk \{{ $labels.app }} i \{{ $labels.namespace }} sin selftest for å se hva som er galt."
+          consequence: Application is unavailable
+          action: "`kubectl describe pod <podname>` -> `kubectl logs <podname>`"
+          summary: |-
+            This is a multi-line summary with
+            linebreaks and everything. Here you can give a more detailed
+            summary of what this alert is about
         labels:
-          namespace: {{ namespace }}
-          severity: warning
+          namespace: meldekort
+          severity: critical

--- a/.nais/alerts-gcp.yaml
+++ b/.nais/alerts-gcp.yaml
@@ -1,7 +1,10 @@
-    # Sjekker om det er feil ved selftest
-    - alert: Feil i selftest
-      expr: selftests_aggregate_result_status{kubernetes_namespace="{{ namespace }}"} > 0
-      for: 1m
-      description: '*\{{ $labels.app }}* har feil i selftest.'
-      action: "Sjekk \{{ $labels.app }} i \{{ $labels.kubernetes_namespace }} sin selftest for å se hva som er galt."
-      severity: warning
+      # Sjekker om det er feil ved selftest
+      - alert: Feil i selftest
+        expr: selftests_aggregate_result_status{namespace="{{ namespace }}"} > -1
+        for: 1m
+        annotations:
+          consequence: '*\{{ $labels.app }}* har feil i selftest.'
+          action: "Sjekk \{{ $labels.app }} i \{{ $labels.namespace }} sin selftest for å se hva som er galt."
+        labels:
+          namespace: {{ namespace }}
+          severity: warning

--- a/.nais/alerts-gcp.yaml
+++ b/.nais/alerts-gcp.yaml
@@ -1,23 +1,10 @@
-#      # Sjekker om det er feil ved selftest
-#      - alert: Feil i selftest
-#        expr: selftests_aggregate_result_status{namespace="{{ namespace }}"} > -1
-#        for: 1m
-#        annotations:
-#          consequence: '*\{{ $labels.app }}* har feil i selftest.'
-#          action: "Sjekk \{{ $labels.app }} i \{{ $labels.namespace }} sin selftest for å se hva som er galt."
-#        labels:
-#          namespace: {{ namespace }}
-#          severity: warning
-      - alert: InstanceDown
-        expr: count(up) == 0
-        for: 5m
+      # Sjekker om det er feil ved selftest
+      - alert: Feil i selftest
+        expr: selftests_aggregate_result_status{namespace="{{ namespace }}"} > -1
+        for: 1m
         annotations:
-          consequence: Application is unavailable
-          action: "`kubectl describe pod <podname>` -> `kubectl logs <podname>`"
-          summary: |-
-            This is a multi-line summary with
-            linebreaks and everything. Here you can give a more detailed
-            summary of what this alert is about
+          consequence: '*\{{ $labels.app }}* har feil i selftest.'
+          action: "Sjekk \{{ $labels.app }} i \{{ $labels.namespace }} sin selftest for å se hva som er galt."
         labels:
-          namespace: meldekort
-          severity: critical
+          namespace: {{ namespace }}
+          severity: warning

--- a/.nais/meldeplikt-alerts-dev.yaml
+++ b/.nais/meldeplikt-alerts-dev.yaml
@@ -3,6 +3,8 @@ kind: PrometheusRule
 metadata:
   name: {{ name }}
   namespace: {{ namespace }}
+  labels:
+    team: {{ team }}
 spec:
   groups:
     - name: {{ name }}

--- a/.nais/meldeplikt-alerts-dev.yaml
+++ b/.nais/meldeplikt-alerts-dev.yaml
@@ -1,12 +1,8 @@
-apiVersion: nais.io/v1
-kind: Alert
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
 metadata:
   name: {{ name }}
-  namespace: {{ namespace }}
-  labels:
-    team: {{ team }}
 spec:
-  receivers:
-    slack:
-      channel: '#{{ channel }}-dev'
-  alerts:
+  groups:
+    - name: {{ name }}
+      rules:

--- a/.nais/meldeplikt-alerts-dev.yaml
+++ b/.nais/meldeplikt-alerts-dev.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ name }}
+  namespace: {{ namespace }}
 spec:
   groups:
     - name: {{ name }}

--- a/.nais/meldeplikt-alerts.yaml
+++ b/.nais/meldeplikt-alerts.yaml
@@ -1,13 +1,11 @@
-apiVersion: nais.io/v1
-kind: Alert
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
 metadata:
   name: {{ name }}
   namespace: {{ namespace }}
   labels:
     team: {{ team }}
 spec:
-  receivers:
-    slack:
-      channel: '#{{ channel }}'
-      prependText: "<!here> | "
-  alerts:
+  groups:
+    - name: {{ name }}
+      rules:

--- a/.nais/vars.yaml
+++ b/.nais/vars.yaml
@@ -1,2 +1,3 @@
 name: meldeplikt-alerts
 namespace: meldekort
+team: meldekort

--- a/.nais/vars.yaml
+++ b/.nais/vars.yaml
@@ -1,4 +1,2 @@
 name: meldeplikt-alerts
 namespace: meldekort
-team: meldekort
-channel: 'team-meldeplikt-alerts'

--- a/README.md
+++ b/README.md
@@ -5,13 +5,6 @@ Lager alerts for Team meldeplikt sine applikasjoner.
 
 For mer informasjon om hvordan alarmene fungerer se: `https://doc.nais.io/observability/alerts`.
 
-## Komme i gang
-Bruk Prometheus for å teste queries.
-- `https://prometheus.nais.adeo.no` (prod-fss)
-- `https://prometheus.nais.preprod.local` (dev-fss)
-- `https://prometheus.prod-gcp.nais.io` (prod-gcp)
-- `https://prometheus.dev-gcp.nais.io` (dev-gcp)
-
 ## Utvikling
 Generelle alerts for alle miljø legges i `alerts-common.yaml` mens alerts for et gitt cluster eller applikasjon legges i `alerts-<cluster>>.yaml`.
 Ved deploy merges generelle alerts og cluster-spesifikke alerts sammen i en fil.
@@ -32,4 +25,4 @@ Endring på master-branch trigger deploy til alle miljø.
 Triggede alerts dukker opp i #team-meldeplikt-alerts på Slack.
 
 ## For NAV ansatte
-Vi er tilgjenngelig på slack kanalen #team-meldeplikt.
+Vi er tilgjengelig på Slack i kanalen #team-meldeplikt.


### PR DESCRIPTION
Bakgrunn - https://nav-it.slack.com/archives/C01DE3M9YBV/p1676019103101669.

- oppdatert fra å bruke `Alert`-ressurs i clusteret til å bruke Prometheus Operators `PrometheusRule`.
- tilpasset alerter til ny syntaks (namespace må settes eksplisitt for hver alert for nå)
- `kubernetes_pod_name` og `kubernetes_namespace` endres til hhv. `pod` og `namespace`, ellers ingen funksjonelle endringer
- beholder både `meldeplikt-alerts.yaml` og `meldeplikt-alerts.yaml` for nå selv om de er like (evt. om vi lager en egen config for prod etter hvert, men doc'en er litt tynn enda...)

Jeg tar en sjekk på Grafana-dashbordene etter at det blir skrudd om til ny Prometheus 15. februar.